### PR TITLE
Use new data model differentiating single line loop blocks from simple blocks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,9 @@ packages = find:
 python_requires = >= 3.8
 include_package_data = True
 install_requires =
+    numpy
     pandas
+    typing-extensions
 
 
 [options.extras_require]

--- a/starfile/functions.py
+++ b/starfile/functions.py
@@ -21,11 +21,11 @@ def read(filename: PathLike, read_n_blocks: int = None, always_dict: bool = Fals
     default behaviour in the case of only one data block being present in the STAR file is to
     return only a dataframe, this can be changed by setting 'always_dict=True'
     """
-    star = StarParser(filename, read_n_blocks=read_n_blocks)
-    if len(star.dataframes) == 1 and always_dict is False:
+    star = StarParser(filename, n_blocks_to_read=read_n_blocks)
+    if len(star.data_blocks) == 1 and always_dict is False:
         return star.first_dataframe
     else:
-        return star.dataframes
+        return star.data_blocks
 
 
 def write(data: Union[pd.DataFrame, Dict[str, pd.DataFrame], List[pd.DataFrame]],

--- a/starfile/functions.py
+++ b/starfile/functions.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
 
 from .parser import StarParser
 from .writer import StarWriter
+from .typing import DataBlock
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -21,22 +22,26 @@ def read(filename: PathLike, read_n_blocks: int = None, always_dict: bool = Fals
     default behaviour in the case of only one data block being present in the STAR file is to
     return only a dataframe, this can be changed by setting 'always_dict=True'
     """
-    star = StarParser(filename, n_blocks_to_read=read_n_blocks)
-    if len(star.data_blocks) == 1 and always_dict is False:
-        return star.first_dataframe
+    parser = StarParser(filename, n_blocks_to_read=read_n_blocks)
+    if len(parser.data_blocks) == 1 and always_dict is False:
+        return list(parser.data_blocks.values())[0]
     else:
-        return star.data_blocks
+        return parser.data_blocks
 
 
-def write(data: Union[pd.DataFrame, Dict[str, pd.DataFrame], List[pd.DataFrame]],
-          filename: PathLike,
-          float_format: str = '%.6f', sep: str = '\t', na_rep: str = '<NA>',
-          overwrite: bool = False, force_loop: bool = True):
-    """
-    Write dataframes from pandas dataframe(s) to a star file
-
-    data can be a single dataframe, a list of dataframes or a dict of dataframes
-    float format defaults to 6 digits after the decimal point
-    """
-    StarWriter(data, filename=filename, float_format=float_format, overwrite=overwrite,
-               na_rep=na_rep, sep=sep, force_loop=force_loop)
+def write(
+    data: Union[DataBlock, Dict[str, DataBlock], List[DataBlock]],
+    filename: PathLike,
+    float_format: str = '%.6f',
+    sep: str = '\t',
+    na_rep: str = '<NA>',
+    **kwargs,
+):
+    """Write data blocks as STAR files."""
+    StarWriter(
+        data,
+        filename=filename,
+        float_format=float_format,
+        na_rep=na_rep,
+        separator=sep
+    )

--- a/starfile/parser.py
+++ b/starfile/parser.py
@@ -7,15 +7,12 @@ from linecache import getline
 import numpy as np
 import pandas as pd
 from pathlib import Path
-from typing import TYPE_CHECKING, Union, Optional, Dict, TypeAlias, Tuple
+from typing import TYPE_CHECKING, Union, Optional, Dict, Tuple
+
+from starfile.typing import DataBlock
 
 if TYPE_CHECKING:
     from os import PathLike
-
-DataBlock: TypeAlias = Union[
-    pd.DataFrame,
-    Dict[str, Union[str, int, float]]
-]
 
 
 class StarParser:

--- a/starfile/parser.py
+++ b/starfile/parser.py
@@ -1,217 +1,145 @@
 from __future__ import annotations
 
-from collections import OrderedDict
+from collections import deque
 from io import StringIO
+from linecache import getline
 
+import numpy as np
 import pandas as pd
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Union, Optional
-
-from .utils import TextBuffer, TextCrawler
+from typing import TYPE_CHECKING, Union, Optional, Dict, TypeAlias, Tuple
 
 if TYPE_CHECKING:
     from os import PathLike
 
+DataBlock: TypeAlias = Union[
+    pd.DataFrame,
+    Dict[str, Union[str, int, float]]
+]
+
 
 class StarParser:
-    def __init__(self, filename: PathLike, read_n_blocks: Optional[int] = None):
+    filename: Path
+    n_lines_in_file: int
+    n_blocks_to_read: int
+    current_line_number: int
+    data_blocks: Dict[DataBlock]
+
+    def __init__(self, filename: PathLike, n_blocks_to_read: Optional[int] = None):
         # set filename, with path checking
+        filename = Path(filename)
+        if not filename.exists():
+            raise FileNotFoundError(filename)
         self.filename = filename
 
-        # initialise attributes for parsing
-        self.text_buffer = TextBuffer()
-        self.crawler = TextCrawler(self.filename)
-        self.read_n_blocks = read_n_blocks
-        self._dataframes = OrderedDict()
-        self._current_dataframe_index = 0
-        self._initialise_n_lines()
+        # setup for parsing
+        self.data_blocks = {}
+        self.n_lines_in_file = count_lines(self.filename)
+        self.n_blocks_to_read = n_blocks_to_read
 
         # parse file
+        self.current_line_number = 0
         self.parse_file()
 
+    @property
+    def current_line(self) -> str:
+        return getline(str(self.filename), self.current_line_number).strip()
+
     def parse_file(self):
-        while self.crawler.current_line_number <= self.n_lines:
-            if len(self.dataframes) == self.read_n_blocks:
+        while self.current_line_number <= self.n_lines_in_file:
+            if len(self.data_blocks) == self.n_blocks_to_read:
                 break
+            elif self.current_line.startswith('data_'):
+                block_name, block = self._parse_data_block()
+                self.data_blocks[block_name] = block
+            else:
+                self.current_line_number += 1
 
-            elif self.crawler.current_line.startswith('data_'):
-                self._parse_data_block()
+    def _parse_data_block(self) -> Tuple[str, DataBlock]:
+        # current line starts with 'data_foo'
+        block_name = self.current_line[5:]  # 'data_foo' -> 'foo'
+        self.current_line_number += 1
 
-            if not self.crawler.current_line.startswith('data_'):
-                self.crawler.increment_line_number()
+        # iterate over file,
+        while self.current_line_number <= self.n_lines_in_file:
+            self.current_line_number += 1
+            if self.current_line.startswith('loop_'):
+                return block_name, self._parse_loop_block()
+            elif self.current_line.startswith('_'):  # line is simple block
+                return block_name, self._parse_simple_block()
 
-        self.dataframes_to_numeric()
-        return
-
-    def _parse_data_block(self):
-        self.current_block_name = self._block_name_from_current_line()
-
-        while self.crawler.current_line_number <= self.n_lines:
-            self.crawler.increment_line_number()
-            line = self.crawler.current_line
-
-            if line.startswith('loop_'):
-                self._parse_loop_block()
-                return
-
-            elif line.startswith(
-                'data_') or self.crawler.current_line_number == self.n_lines:
-                self._parse_simple_block_from_buffer()
-                return
-
-            self.text_buffer.add_line(line)
-        return
-
-    def _parse_simple_block_from_buffer(self):
-        data = self._clean_simple_block_in_buffer()
-
-        df = self._cleaned_simple_block_to_dataframe(data)
-        df.name = self._current_data_block_name
-        self._add_dataframe(df)
-
-        self.text_buffer.clear()
-
-    def _parse_loop_block(self):
-        self.crawler.increment_line_number()
-        header = self._parse_loop_header()
-        df = self._parse_loop_data()
-        if df is None:
-            df = pd.DataFrame({h: None for h in header}, index=[0])
-        df.columns = header
-        df.name = self._current_data_block_name
-        self._add_dataframe(df)
-        return
-
-    @property
-    def filename(self):
-        return self._filename
-
-    @filename.setter
-    def filename(self, filename: Union[str, Path]):
-        filename = Path(filename)
-        if filename.exists():
-            self._filename = filename
-        else:
-            raise FileNotFoundError
-
-    @property
-    def n_lines(self):
-        return self._n_lines
-
-    def _initialise_n_lines(self):
-        self._n_lines = self.crawler.count_lines()
-
-    @property
-    def dataframes(self):
-        return self._dataframes
-
-    def _add_dataframe(self, df: pd.DataFrame):
-        key = self._get_dataframe_key(df)
-        self.dataframes[key] = df
-        self._increment_dataframe_index()
-
-    @property
-    def current_block_name(self):
-        return self._current_data_block_name
-
-    @current_block_name.setter
-    def current_block_name(self, name: str):
-        self._current_data_block_name = name
-
-    @property
-    def current_dataframe_index(self):
-        return self._current_dataframe_index
-
-    def _increment_dataframe_index(self):
-        self._current_dataframe_index += 1
-
-    def _get_dataframe_key(self, df):
-        name = df.name
-
-        if name == '' or isinstance(name, int) or name in self.dataframes.keys():
-            return self._current_dataframe_index
-        else:
-            return df.name
-
-    def _clean_simple_block_in_buffer(self):
-        clean_datablock = {}
-
-        for line in self.text_buffer.buffer:
-            if line == '' or line.startswith('#'):
-                continue
-
-            heading_name = self.heading_from_line(line)
-            value = line.split()[1]
-            clean_datablock[heading_name] = value
-
-        return clean_datablock
-
-    @staticmethod
-    def _cleaned_simple_block_to_dataframe(data: dict):
-        return pd.DataFrame(data, columns=data.keys(), index=[0])
-
-    def _parse_loop_header(self) -> List[str]:
-        self.text_buffer.clear()
-
-        while self.crawler.current_line.startswith('_'):
-            heading = self.heading_from_line(self.crawler.current_line)
-            self.text_buffer.add_line(heading)
-            self.crawler.increment_line_number()
-
-        return self.text_buffer.buffer
-
-    def _parse_loop_data(self) -> Union[pd.DataFrame, None]:
-        self.text_buffer.clear()
-
-        while self.crawler.current_line_number <= self.n_lines:
-            current_line = self.crawler.current_line
-            if current_line.startswith('data_'):
+    def _parse_simple_block(self) -> Dict[str, Union[str, int, float]]:
+        block = {}
+        while self.current_line_number <= self.n_lines_in_file:
+            if self.current_line.startswith('data'):
                 break
-            self.text_buffer.add_line(current_line)
-            self.crawler.increment_line_number()
+            elif self.current_line.startswith('_'):  # '_foo bar'
+                k, v = self.current_line.split()
+                block[k[1:]] = numericise(v)
+            self.current_line_number += 1
+        return block
 
-        # check whether the buffer is empty
-        if self.text_buffer.is_empty:
-            return None
+    def _parse_loop_block(self) -> pd.DataFrame:
+        # parse loop header
+        loop_column_names = deque()
+        self.current_line_number += 1
 
-        df = pd.read_csv(
-            StringIO(self.text_buffer.as_str()),
-            delim_whitespace=True,
-            header=None,
-            comment='#'
-        )
+        while self.current_line.startswith('_'):
+            column_name = self.current_line.split()[0][1:]
+            loop_column_names.append(column_name)
+            self.current_line_number += 1
+
+        # now parse the loop block data
+        loop_data = deque()
+        while self.current_line_number <= self.n_lines_in_file:
+            if self.current_line.startswith('data_'):
+                break
+            loop_data.append(self.current_line)
+            self.current_line_number += 1
+        loop_data = '\n'.join(loop_data)
+        if loop_data[-2:] != '\n':
+            loop_data += '\n'
+
+        # put string data into a dataframe
+        if loop_data == '\n':
+            n_cols = len(loop_column_names)
+            df = pd.DataFrame(np.zeros(shape=(0, n_cols)))
+        else:
+            df = pd.read_csv(
+                StringIO(loop_data),
+                delim_whitespace=True,
+                header=None,
+                comment='#'
+            )
+            df = df.apply(pd.to_numeric, errors='ignore')
+            df.columns = loop_column_names
         return df
 
-    def dataframes_to_numeric(self):
-        """
-        Converts strings in dataframes into numerical values where possible
 
-        applying pd.to_numeric causes loss of 'name' attribute of DataFrame,
-        need to extract name and reapply inline
-        """
-        for key, df in self.dataframes.items():
-            name = getattr(df, 'name', None)
-            self.dataframes[key] = df.apply(pd.to_numeric, errors='ignore')
-            if name is not None:
-                self.dataframes[key].name = name
+def count_lines(file: Path) -> int:
+    with open(file, 'rb') as f:
+        return sum(1 for _ in f)
 
-    @staticmethod
-    def _block_name_from_line(line: str):
-        return line[5:]
 
-    def _block_name_from_current_line(self):
-        return self._block_name_from_line(self.crawler.current_line)
+def block_name_from_line(line: str) -> str:
+    """'data_general' -> 'general'"""
+    return line[5:]
 
-    @staticmethod
-    def heading_from_line(line: str):
-        return line.split()[0][1:]
 
-    @property
-    def first_dataframe(self):
-        return self.dataframe_at_index(0)
+def heading_from_line(line: str) -> str:
+    """'_rlnSpectralIndex #1' -> 'rlnSpectralIndex'."""
+    return line.split()[0][1:]
 
-    def dataframe_at_index(self, idx: int):
-        return self.dataframes_as_list()[idx]
 
-    def dataframes_as_list(self):
-        return list(self.dataframes.values())
+def numericise(value: str) -> Union[str, int, float]:
+    try:
+        # Try to convert the string value to an integer
+        value = int(value)
+    except ValueError:
+        try:
+            # If it's not an integer, try to convert it to a float
+            value = float(value)
+        except ValueError:
+            # If it's not a float either, leave it as a string
+            value = value
+    return value

--- a/starfile/typing.py
+++ b/starfile/typing.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from typing import TypeAlias, Union, Dict
+
+import pandas as pd
+
+DataBlock: TypeAlias = Union[
+    pd.DataFrame,
+    Dict[str, Union[str, int, float]]
+]

--- a/starfile/typing.py
+++ b/starfile/typing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TypeAlias, Union, Dict
+from typing import Union, Dict
+from typing_extensions import TypeAlias
 
 import pandas as pd
 

--- a/starfile/writer.py
+++ b/starfile/writer.py
@@ -23,7 +23,7 @@ class StarWriter:
         data_blocks: Union[DataBlock, Dict[str, DataBlock], List[DataBlock]],
         filename: PathLike,
         float_format: str = '%.6f',
-        sep: str = '\t',
+        separator: str = '\t',
         na_rep: str = '<NA>',
     ):
         # coerce data
@@ -32,7 +32,7 @@ class StarWriter:
         # write
         self.filename = Path(filename)
         self.float_format = float_format
-        self.sep = sep
+        self.sep = separator
         self.na_rep = na_rep
         self.buffer = TextBuffer()
         self.backup_if_file_exists()

--- a/starfile/writer.py
+++ b/starfile/writer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections import OrderedDict
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Union, Dict, List

--- a/starfile/writer.py
+++ b/starfile/writer.py
@@ -17,8 +17,10 @@ __version__ = get_distribution("starfile").version
 
 
 class StarWriter:
-    def __init__(self, dataframes: Union[pd.DataFrame, Dict[pd.DataFrame], List[pd.DataFrame]],
-                 filename: PathLike, overwrite: bool = False, float_format: str = '%.6f',
+    def __init__(self, dataframes: Union[
+        pd.DataFrame, Dict[pd.DataFrame], List[pd.DataFrame]],
+                 filename: PathLike, overwrite: bool = False,
+                 float_format: str = '%.6f',
                  sep: str = '\t', na_rep: str = '<NA>', force_loop: bool = False):
         self.overwrite = overwrite
         self.filename = filename
@@ -39,7 +41,8 @@ class StarWriter:
         return self._dataframes
 
     @dataframes.setter
-    def dataframes(self, dataframes: Union[pd.DataFrame, Dict[pd.DataFrame], List[pd.DataFrame]]):
+    def dataframes(self, dataframes: Union[
+        pd.DataFrame, Dict[pd.DataFrame], List[pd.DataFrame]]):
         if isinstance(dataframes, pd.DataFrame):
             self._dataframes = self.coerce_dataframe(dataframes)
         elif isinstance(dataframes, dict):
@@ -47,7 +50,8 @@ class StarWriter:
         elif isinstance(dataframes, list):
             self._dataframes = self.coerce_list(dataframes)
         else:
-            raise ValueError(f'Expected a DataFrame, Dict or List object, got {type(dataframes)}')
+            raise ValueError(
+                f'Expected a DataFrame, Dict or List object, got {type(dataframes)}')
 
     @staticmethod
     def coerce_dataframe(df: pd.DataFrame):
@@ -112,7 +116,8 @@ class StarWriter:
 
     def write_loopheader(self, df: pd.DataFrame):
         self.buffer.add_line('loop_')
-        lines = [f'_{column_name} #{idx}' for idx, column_name in enumerate(df.columns, 1)]
+        lines = [f'_{column_name} #{idx}' for idx, column_name in
+                 enumerate(df.columns, 1)]
 
         for line in lines:
             self.buffer.add_line(line)

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -27,10 +27,3 @@ cars = {'Brand': ['Honda_Civic', 'Toyota_Corolla', 'Ford_Focus', 'Audi_A4'],
         'Price': [22000, 25000, 27000, 35000]
         }
 test_df = pd.DataFrame.from_dict(cars)
-
-
-# Attributes of certain files
-loop_simple_columns = ['rlnCoordinateX', 'rlnCoordinateY', 'rlnCoordinateZ',
-       'rlnMicrographName', 'rlnMagnification', 'rlnDetectorPixelSize',
-       'rlnCtfMaxResolution', 'rlnImageName', 'rlnCtfImage', 'rlnAngleRot',
-       'rlnAngleTilt', 'rlnAnglePsi']

--- a/tests/data/single_line_end_of_multiblock.star
+++ b/tests/data/single_line_end_of_multiblock.star
@@ -1,6 +1,6 @@
 # multi-current_line, python engine
 
-data_block_3
+data_block_1
 
 loop_
 _rlnImageName #1
@@ -13,7 +13,7 @@ _rlnCoordinateZ #5
 
 # single-current_line, c engine
 
-data_block_3
+data_block_2
 
 loop_
 _rlnImageName #1

--- a/tests/data/single_line_middle_of_multiblock.star
+++ b/tests/data/single_line_middle_of_multiblock.star
@@ -1,6 +1,6 @@
-# single-current_line, python engine
+# single-line, python engine
 
-data_block_3
+data_block_1
 
 loop_
 _rlnImageName #1
@@ -10,9 +10,9 @@ _rlnCoordinateY #4
 _rlnCoordinateZ #5
 000001@0001_sum_particles.mrcs 0001_sum.mrc   587.000000  1268.000000    -51.52270
 
-# single-current_line, c engine
+# single-line, c engine
 
-data_block_3
+data_block_2
 
 loop_
 _rlnImageName #1

--- a/tests/test_functional_interface.py
+++ b/tests/test_functional_interface.py
@@ -29,29 +29,14 @@ def test_write():
     assert output_file.exists()
 
 
-def test_write_fails_to_overwrite_without_flag():
-    output_file = test_data_directory / 'test_overwrite_flag.star'
-    starfile.write(test_df, output_file, overwrite=True)
-
+def test_write_overwrites_with_backup():
+    output_file = test_data_directory / 'test_overwrite_backup.star'
+    starfile.write(test_df, output_file)
     assert output_file.exists()
-    with pytest.raises(FileExistsError):
-        starfile.write(test_df, output_file, overwrite=False)
-        starfile.new(test_df, output_file)
 
-
-def test_write_overwrites_with_flag():
-    output_file = test_data_directory / 'test_overwrite_flag.star'
-    starfile.write(test_df, output_file, overwrite=True)
-
-    assert output_file.exists()
-    starfile.write(test_df, output_file, overwrite=True)
-
-
-def test_write_with_float_format():
-    output_file = test_data_directory / 'test_write_with_float_format.star'
-    test_df['float_col'] = 1.23456789
-    starfile.write(test_df, output_file, float_format='%.3f', overwrite=True)
-    assert output_file.exists()
+    starfile.write(test_df, output_file)
+    backup = test_data_directory / 'test_overwrite_backup.star~'
+    assert backup.exists()
 
 
 def test_read_non_existent_file():

--- a/tests/test_read_write_round_trip.py
+++ b/tests/test_read_write_round_trip.py
@@ -1,4 +1,4 @@
-from .constants import two_single_line_loop_blocks
+from .constants import two_single_line_loop_blocks, postprocess
 
 import starfile
 import pandas as pd
@@ -19,3 +19,20 @@ def test_round_trip_two_single_line_loop_blocks(tmp_path):
     for expected_df, actual_df in zip(expected.values(), star_after_round_trip.values()):
         pd.testing.assert_frame_equal(expected_df, actual_df)
 
+
+def test_round_trip_postprocess(tmp_path):
+    expected = starfile.read(postprocess)
+
+    # write
+    output_file = tmp_path / 'two_single_line_loop_blocks.star'
+    starfile.write(expected, output_file)
+
+    # read
+    star_after_round_trip = starfile.read(output_file)
+
+    # assert
+    for _expected, _actual in zip(expected.values(), star_after_round_trip.values()):
+        if isinstance(_actual, pd.DataFrame):
+            pd.testing.assert_frame_equal(_actual, _expected, atol=1e-6)
+        else:
+            assert _actual == _expected

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -13,21 +13,21 @@ from .constants import loop_simple, postprocess, pipeline, rln31_style, optimise
 def test_write_simple_block():
     s = StarParser(postprocess)
     output_file = test_data_directory / 'basic_block.star'
-    StarWriter(s.dataframes, output_file, overwrite=True)
+    StarWriter(s.data_blocks, output_file, overwrite=True)
     assert output_file.exists()
 
 
 def test_write_loop():
     s = StarParser(loop_simple)
     output_file = test_data_directory / 'loop_block.star'
-    StarWriter(s.dataframes, output_file, overwrite=True)
+    StarWriter(s.data_blocks, output_file, overwrite=True)
     assert output_file.exists()
 
 
 def test_write_multiblock():
     s = StarParser(postprocess)
     output_file = test_data_directory / 'multiblock.star'
-    StarWriter(s.dataframes, output_file, overwrite=True)
+    StarWriter(s.data_blocks, output_file, overwrite=True)
     assert output_file.exists()
 
 
@@ -48,7 +48,7 @@ def test_create_from_dataframes():
     assert output_file.exists()
 
     s = StarParser(output_file)
-    assert len(s.dataframes) == 2
+    assert len(s.data_blocks) == 2
 
 def test_can_write_non_zero_indexed_one_row_dataframe():
     # see PR #13 - https://github.com/alisterburt/starfile/pull/13

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -6,35 +6,34 @@ import pandas as pd
 from starfile.parser import StarParser
 from starfile.writer import StarWriter
 
-from .constants import loop_simple, postprocess, pipeline, rln31_style, optimiser_2d, optimiser_3d, sampling_2d, \
-    sampling_3d, test_data_directory, test_df
+from .constants import loop_simple, postprocess, test_data_directory, test_df
 
 
 def test_write_simple_block():
     s = StarParser(postprocess)
     output_file = test_data_directory / 'basic_block.star'
-    StarWriter(s.data_blocks, output_file, overwrite=True)
+    StarWriter(s.data_blocks, output_file)
     assert output_file.exists()
 
 
 def test_write_loop():
     s = StarParser(loop_simple)
     output_file = test_data_directory / 'loop_block.star'
-    StarWriter(s.data_blocks, output_file, overwrite=True)
+    StarWriter(s.data_blocks, output_file)
     assert output_file.exists()
 
 
 def test_write_multiblock():
     s = StarParser(postprocess)
     output_file = test_data_directory / 'multiblock.star'
-    StarWriter(s.data_blocks, output_file, overwrite=True)
+    StarWriter(s.data_blocks, output_file)
     assert output_file.exists()
 
 
 def test_from_single_dataframe():
     output_file = test_data_directory / 'from_df.star'
 
-    StarWriter(test_df, output_file, overwrite=True)
+    StarWriter(test_df, output_file)
     assert output_file.exists()
 
     s = StarParser(output_file)
@@ -44,15 +43,16 @@ def test_create_from_dataframes():
     dfs = [test_df, test_df]
 
     output_file = test_data_directory / 'from_list.star'
-    StarWriter(dfs, output_file, overwrite=True)
+    StarWriter(dfs, output_file)
     assert output_file.exists()
 
     s = StarParser(output_file)
     assert len(s.data_blocks) == 2
 
+
 def test_can_write_non_zero_indexed_one_row_dataframe():
     # see PR #13 - https://github.com/alisterburt/starfile/pull/13
-    df = pd.DataFrame([[1,2,3]], columns=["A", "B", "C"])
+    df = pd.DataFrame([[1, 2, 3]], columns=["A", "B", "C"])
     df.index += 1
 
     with TemporaryDirectory() as directory:
@@ -62,8 +62,9 @@ def test_can_write_non_zero_indexed_one_row_dataframe():
             output = output_file.read()
 
     expected = (
-        "_A\t\t\t1\n"
-        "_B\t\t\t2\n"
-        "_C\t\t\t3\n"
+        "_A #1\n"
+        "_B #2\n"
+        "_C #3\n"
+        "1\t2\t3"
     )
     assert (expected in output)


### PR DESCRIPTION
This library uses a dict of dataframes as the in memory data model for a STAR file. There is an ambiguity when dealing with single row dataframes, are they simple blocks or loop blocks?

This PR starts work on changing the underlying data model to:
- simple blocks: `dict[str, str | int | float]`
- loop blocks: `pd.DataFrame` (as before)

Thus removing the ambiguity. This will break the API and be released as 0.5.0 when ready

Parser has been heavily reworked and simplified, all parsing tests are passing - haven't touched the writer or the high level functions yet but the bulk of the work is done


