### PR TITLE
Add option to omit field numbers

### DIFF
--- a/src/starfile/functions.py
+++ b/src/starfile/functions.py
@@ -55,7 +55,7 @@ def write(
     na_rep: str = '<NA>',
     quote_character: str = '"',
     quote_all_strings: bool = False,
-    include_field_num: bool = True,
+    include_field_numbers: bool = True,
     **kwargs
 ):
     """Write data to disk in the STAR format.
@@ -73,7 +73,7 @@ def write(
         Separator between values, will be passed to pandas.
     na_rep: str
         Representation of null values, will be passed to pandas.
-    include_field_num: bool
+    include_field_numbers: bool
         Whether field numbers should be included after field names in the ouput file. 
         Default is True which includes field numbers (i.e. `_rlnImageName #1`) and is 
         compatible with RELION and Python STOPGAP. False excludes field numbers (i.e. 
@@ -87,7 +87,7 @@ def write(
         separator=sep,
         quote_character=quote_character,
         quote_all_strings=quote_all_strings,
-        include_field_num=include_field_num,
+        include_field_numbers=include_field_numbers,
     ).write()
 
 

--- a/src/starfile/functions.py
+++ b/src/starfile/functions.py
@@ -55,6 +55,7 @@ def write(
     na_rep: str = '<NA>',
     quote_character: str = '"',
     quote_all_strings: bool = False,
+    include_field_num: bool = True,
     **kwargs
 ):
     """Write data to disk in the STAR format.
@@ -72,6 +73,11 @@ def write(
         Separator between values, will be passed to pandas.
     na_rep: str
         Representation of null values, will be passed to pandas.
+    include_field_num: bool
+        Whether field numbers should be included after field names in the ouput file. 
+        Default is True which includes field numbers (i.e. `_rlnImageName #1`) and is 
+        compatible with RELION and Python STOPGAP. False excludes field numbers (i.e. 
+        `_motl_idx`) and is compatible with legacy/MATLAB STOPGAP.
     """
     StarWriter(
         data,
@@ -81,6 +87,7 @@ def write(
         separator=sep,
         quote_character=quote_character,
         quote_all_strings=quote_all_strings,
+        include_field_num=include_field_num,
     ).write()
 
 

--- a/src/starfile/writer.py
+++ b/src/starfile/writer.py
@@ -27,6 +27,7 @@ class StarWriter:
         na_rep: str = '<NA>',
         quote_character: str = '"',
         quote_all_strings: bool = False,
+        include_field_num: bool = True,
     ):
         # coerce data
         self.data_blocks = self.coerce_data_blocks(data_blocks)
@@ -40,6 +41,7 @@ class StarWriter:
         self.na_rep = na_rep
         self.quote_character = quote_character
         self.quote_all_strings = quote_all_strings
+        self.include_field_num = include_field_num
         self.buffer = TextBuffer()
         self.backup_if_file_exists()
 
@@ -93,7 +95,8 @@ class StarWriter:
                     separator=self.sep,
                     na_rep=self.na_rep,
                     quote_character=self.quote_character,
-                    quote_all_strings=self.quote_all_strings
+                    quote_all_strings=self.quote_all_strings,
+                    include_field_num=self.include_field_num,
                 ):
                     yield line
 
@@ -164,7 +167,7 @@ def loop_block(
     na_rep: str = '<NA>',
     quote_character: str = '"',
     quote_all_strings: bool = False,
-    include_line_num: bool = True,
+    include_field_num: bool = True,
 ) -> Generator[str, None, None]:
 
     # Header
@@ -172,7 +175,7 @@ def loop_block(
     yield ''
     yield 'loop_'
     for idx, column_name in enumerate(df.columns, 1):
-        yield f'_{column_name} #{idx}' if include_line_num else f'_{column_name}'
+        yield f'_{column_name} #{idx}' if include_field_num else f'_{column_name}'
 
     # Data
     for line in df.map(lambda x:

--- a/src/starfile/writer.py
+++ b/src/starfile/writer.py
@@ -163,7 +163,8 @@ def loop_block(
     separator: str = '\t',
     na_rep: str = '<NA>',
     quote_character: str = '"',
-    quote_all_strings: bool = False
+    quote_all_strings: bool = False,
+    include_line_num: bool = True,
 ) -> Generator[str, None, None]:
 
     # Header
@@ -171,7 +172,7 @@ def loop_block(
     yield ''
     yield 'loop_'
     for idx, column_name in enumerate(df.columns, 1):
-        yield f'_{column_name} #{idx}'
+        yield f'_{column_name} #{idx}' if include_line_num else f'_{column_name}'
 
     # Data
     for line in df.map(lambda x:

--- a/src/starfile/writer.py
+++ b/src/starfile/writer.py
@@ -27,7 +27,7 @@ class StarWriter:
         na_rep: str = '<NA>',
         quote_character: str = '"',
         quote_all_strings: bool = False,
-        include_field_num: bool = True,
+        include_field_numbers: bool = True,
     ):
         # coerce data
         self.data_blocks = self.coerce_data_blocks(data_blocks)
@@ -41,7 +41,7 @@ class StarWriter:
         self.na_rep = na_rep
         self.quote_character = quote_character
         self.quote_all_strings = quote_all_strings
-        self.include_field_num = include_field_num
+        self.include_field_numbers = include_field_numbers
         self.buffer = TextBuffer()
         self.backup_if_file_exists()
 
@@ -96,7 +96,7 @@ class StarWriter:
                     na_rep=self.na_rep,
                     quote_character=self.quote_character,
                     quote_all_strings=self.quote_all_strings,
-                    include_field_num=self.include_field_num,
+                    include_field_numbers=self.include_field_numbers,
                 ):
                     yield line
 
@@ -167,7 +167,7 @@ def loop_block(
     na_rep: str = '<NA>',
     quote_character: str = '"',
     quote_all_strings: bool = False,
-    include_field_num: bool = True,
+    include_field_numbers: bool = True,
 ) -> Generator[str, None, None]:
 
     # Header
@@ -175,7 +175,7 @@ def loop_block(
     yield ''
     yield 'loop_'
     for idx, column_name in enumerate(df.columns, 1):
-        yield f'_{column_name} #{idx}' if include_field_num else f'_{column_name}'
+        yield f'_{column_name} #{idx}' if include_field_numbers else f'_{column_name}'
 
     # Data
     for line in df.map(lambda x:

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -72,18 +72,18 @@ def test_can_write_non_zero_indexed_one_row_dataframe():
     assert (expected in output)
 
 
-@pytest.mark.parametrize("include_field_num, expected", 
+@pytest.mark.parametrize("include_field_numbers, expected", 
                          [
                              (True, "_Brand #1\n_Price #2\n"),
                              (False, "_Brand\n_Price\n"),
                          ])
-def test_include_exclude_field_numbers(include_field_num, expected):
+def test_include_exclude_field_numbers(include_field_numbers, expected):
     with TemporaryDirectory() as directory:
         filename = join_path(directory, "test.star")
         StarWriter(
             test_df, 
             filename, 
-            include_field_num=include_field_num
+            include_field_numbers=include_field_numbers
         ).write()
         with open(filename) as output_file:
             output = output_file.read()

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -72,21 +72,21 @@ def test_can_write_non_zero_indexed_one_row_dataframe():
     assert (expected in output)
 
 
-def test_exclude_field_numbers():
+@pytest.mark.parametrize("include_field_num, expected", 
+                         [
+                             (True, "_Brand #1\n_Price #2\n"),
+                             (False, "_Brand\n_Price\n"),
+                         ])
+def test_include_exclude_field_numbers(include_field_num, expected):
     with TemporaryDirectory() as directory:
         filename = join_path(directory, "test.star")
-        StarWriter(test_df, filename, include_field_num=False).write()
+        StarWriter(
+            test_df, 
+            filename, 
+            include_field_num=include_field_num
+        ).write()
         with open(filename) as output_file:
             output = output_file.read()
-
-    expected = (
-        "_Brand\n"
-        "_Price\n"
-        "Honda_Civic\t22000\n"
-        "Toyota_Corolla\t25000\n"
-        "Ford_Focus\t27000\n"
-        "Audi_A4\t35000\n"
-    )
     assert (expected in output)
 
 

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -72,6 +72,24 @@ def test_can_write_non_zero_indexed_one_row_dataframe():
     assert (expected in output)
 
 
+def test_exclude_field_numbers():
+    with TemporaryDirectory() as directory:
+        filename = join_path(directory, "test.star")
+        StarWriter(test_df, filename, include_field_num=False).write()
+        with open(filename) as output_file:
+            output = output_file.read()
+
+    expected = (
+        "_Brand\n"
+        "_Price\n"
+        "Honda_Civic\t22000\n"
+        "Toyota_Corolla\t25000\n"
+        "Ford_Focus\t27000\n"
+        "Audi_A4\t35000\n"
+    )
+    assert (expected in output)
+
+
 @pytest.mark.parametrize("quote_character, quote_all_strings, num_quotes", 
                          [('"', False, 6),
                           ('"', True, 8),


### PR DESCRIPTION
I hope to use this package in Python STOPGAP but it is imperative that the star files produced (e.g. motls, tomolists, parameters) are compatible with legacy MATLAB STOPGAP. The files produced by this package are incompatible with MATLAB STOPGAP in a couple ways. One of which is the inclusion of field numbers after field names, i.e., a field name in the loop block is rendered as `_fieldname #n`. 

This PR creates the `include_field_num` option to omit that number such that the field name would be just `_fieldname`. `include_field_num` is optional and defaults to True for back compatibility.