### PR TITLE
correct typo in multiple data block example

### DIFF
--- a/docs/examples/multi_block.md
+++ b/docs/examples/multi_block.md
@@ -65,7 +65,7 @@ particle_df = star['particles']
     `starfile.read` can be forced to always return a dictionary of entries.
 
     ```python
-    starfile.read('particles.star', force_dict=True)
+    starfile.read('particles.star', always_dict=True)
     ```
 
 ## Writing


### PR DESCRIPTION
The multiple data block example in the documentation mistakenly refers to an argument `force_dict` when this is `always_dict`:

https://github.com/teamtomo/starfile/blob/13d35c76d3a9e394fe8913ffc495aa56f745e56d/src/starfile/functions.py#L29-L30

https://github.com/teamtomo/starfile/blob/13d35c76d3a9e394fe8913ffc495aa56f745e56d/src/starfile/functions.py#L38-L39