### PR TITLE
fix: removed unnecessary line skip

### DIFF
--- a/src/starfile/parser.py
+++ b/src/starfile/parser.py
@@ -65,7 +65,6 @@ class StarParser:
     def _parse_data_block(self) -> Tuple[str, DataBlock]:
         # current line starts with 'data_foo'
         block_name = self.current_line[5:]  # 'data_foo' -> 'foo'
-        self.current_line_number += 1
 
         # iterate over file,
         while self.current_line_number <= self.n_lines_in_file:


### PR DESCRIPTION
Is there any reason for this extra line skip?
It prevents being able to read star files that don't have an empty line between the data_ and loop_ lines (e.g. relion mtf star files)